### PR TITLE
add jenkins static worker taskdef override

### DIFF
--- a/services/shared/infrastructure/cdk/src/jenkins/docker/jenkinsLeader/casc.yaml
+++ b/services/shared/infrastructure/cdk/src/jenkins/docker/jenkinsLeader/casc.yaml
@@ -71,7 +71,7 @@ jenkins:
     - ecs:
         credentialsId: false
         cluster: ${JENKINS_LINUX_WORKER_ECS_CLUSTER_ARN}
-        jenkinsUrl: "https://${JENKINS_DOMAIN_NAME}"
+        jenkinsUrl: "http://leader.jenkins.dev:8080"
         name: "ecs"
         regionName: "us-east-1"
         templates:
@@ -79,6 +79,7 @@ jenkins:
             memoryReservation: 1024
             image: "jenkins/inbound-agent"
             label: "linux"
+            taskDefinitionOverride: "ecsJenkinsStaticLinuxWorker"
             launchType: "FARGATE"
             platformVersion: "LATEST"
             remoteFSRoot: "/home/jenkins"


### PR DESCRIPTION
Added static task def for jenkins worker, otherwise the plugin keeps creating taskdef versions with the same content ALSO
reverted back to using clear text comms between jenkins leader and worker, will take care of this as an enhancement later

```
    // TODO: Make communication between jenkins leader and workers SSL (via ALB)
    // need to use ApplicationMultipleTargetGroupsServiceBaseProps or escape hatches
    // steps are to add a target group to point at container exposed service 50000 (HTTP)
    // and also add a listener on HTTPS 50000
    // and lastly change jenkins config to point at the ssl endpoint in ecs cloud config

```